### PR TITLE
MVTEncoder: Resolutions should be inclusive the last value

### DIFF
--- a/src/MVTEncoder.ts
+++ b/src/MVTEncoder.ts
@@ -332,7 +332,7 @@ export default class MVTEncoder {
 
   snapTileResolution(tileGrid: TileGrid, targetResolution: number): number {
     const resolutions = tileGrid.getResolutions();
-    let resolution = resolutions[resolutions.length - 2]; // the last one is exclusive?
+    let resolution = resolutions[resolutions.length - 1]; //the last one is inclusive
     for (let i = resolutions.length - 2; i >= 0; i--) {
       const r = resolutions[i];
       if (r <= targetResolution) {


### PR DESCRIPTION
Resolutions should be inclusive the last value, see the description for minResolution 
 here https://openlayers.org/en/latest/apidoc/module-ol_layer_Base.html 

`minResolution | number \| undefined | The minimum resolution (**_inclusive_**) at which this layer will be visible.`
